### PR TITLE
Don't create a duplicate root user when dropbear-initramfs installed

### DIFF
--- a/hooks/tailscale
+++ b/hooks/tailscale
@@ -43,7 +43,7 @@ fi
 # whether or not we requested tailscale ssh support at setup time, which is
 # redundant, but we at least avoid doing it when dropbear-initramfs is present
 # as it will prevent that from working.
-if [! -e "/etc/dropbear/initramfs" ]; then
+if [ ! -e "/etc/dropbear/initramfs" ]; then
     # create home
     home=$(mktemp -d "$DESTDIR/root-XXXXXX")
     chmod 0700 "$home"

--- a/hooks/tailscale
+++ b/hooks/tailscale
@@ -39,15 +39,21 @@ if [ -e /etc/tailscale/initramfs/config ]; then
     cp -p "/etc/tailscale/initramfs/config" "$DESTDIR/etc/tailscale/"
 fi
 
-# create home
-home=$(mktemp -d "$DESTDIR/root-XXXXXX")
-chmod 0700 "$home"
-mkdir -m0700 "$home/.ssh"
+# Create the home directory etc for the root user to enable ssh. This happens
+# whether or not we requested tailscale ssh support at setup time, which is
+# redundant, but we at least avoid doing it when dropbear-initramfs is present
+# as it will prevent that from working.
+if [! -e "/etc/dropbear/initramfs" ]; then
+    # create home
+    home=$(mktemp -d "$DESTDIR/root-XXXXXX")
+    chmod 0700 "$home"
+    mkdir -m0700 "$home/.ssh"
 
-#Create user/group required for login
-for x in passwd group; do echo "$x: files"; done >"$DESTDIR/etc/nsswitch.conf"
-echo "root:x:0:0:root:/root:/bin/sh" > "$DESTDIR/etc/passwd"
-echo "root:!:19808:0:99999:7:::" >  "$DESTDIR/etc/shadow"
-echo "root:x:0:" >"$DESTDIR/etc/group"
+    #Create user/group required for login
+    for x in passwd group; do echo "$x: files"; done >"$DESTDIR/etc/nsswitch.conf"
+    echo "root:x:0:0:root:/root:/bin/sh" > "$DESTDIR/etc/passwd"
+    echo "root:!:19808:0:99999:7:::" >  "$DESTDIR/etc/shadow"
+    echo "root:x:0:" >"$DESTDIR/etc/group"
+fi
 
 exit 0

--- a/hooks/tailscale
+++ b/hooks/tailscale
@@ -43,17 +43,21 @@ fi
 # whether or not we requested tailscale ssh support at setup time, which is
 # redundant, but we at least avoid doing it when dropbear-initramfs is present
 # as it will prevent that from working.
-if [ ! -e "/etc/dropbear/initramfs" ]; then
-    # create home
-    home=$(mktemp -d "$DESTDIR/root-XXXXXX")
-    chmod 0700 "$home"
-    mkdir -m0700 "$home/.ssh"
-
-    #Create user/group required for login
-    for x in passwd group; do echo "$x: files"; done >"$DESTDIR/etc/nsswitch.conf"
-    echo "root:x:0:0:root:/root:/bin/sh" > "$DESTDIR/etc/passwd"
-    echo "root:!:19808:0:99999:7:::" >  "$DESTDIR/etc/shadow"
-    echo "root:x:0:" >"$DESTDIR/etc/group"
+if home=$(grep -s '^root:' "$DESTDIR/etc/passwd" | cut -d: -f6) && [ -n "$home" ]; then
+    # Ensure /etc/passwd points at password stored in /etc/shadow
+    sed -Ei -e 's/^root:[^:]+/root:x/' "$DESTDIR/etc/passwd"
+else
+   # create home
+   home=$(mktemp -d "$DESTDIR/root-XXXXXX")
+   chmod 0700 "$home"
+   mkdir -m0700 "$home/.ssh"
+   home=${home#"$DESTDIR"}
 fi
+
+#Create user/group required for login
+for x in passwd group; do echo "$x: files"; done >"$DESTDIR/etc/nsswitch.conf"
+echo "root:x:0:0:root:$home:/bin/sh" > "$DESTDIR/etc/passwd"
+echo "root:!:19808:0:99999:7:::" >  "$DESTDIR/etc/shadow"
+echo "root:x:0:" >"$DESTDIR/etc/group"
 
 exit 0


### PR DESCRIPTION
Without this check, it's not possible to use dropbear-initramfs, even if you don't request the tailscale ssh support (using --ssh when setting up). Two root user directories get created, and it's random which ends up being the one used depending on which order the initramfs hooks execute. This means that although dropbear fires up as the ssh server, it doesn't have access to its authorized_keys file.

I've just changed the tailscale initramfs hook here to skip over creating a root user home directory if dropbear-initramfs is installed. It still redundantly creates it if the --ssh option wasn't specified when doing the initial setup, but I guess that's ok.