### PR TITLE
Fix --hostname switch

### DIFF
--- a/setup-initramfs-tailscale
+++ b/setup-initramfs-tailscale
@@ -40,20 +40,31 @@ cleanup() {
 }
 trap "cleanup" EXIT
 
-# Scan arguments looking for --hostname=VALUE
-FOUND_HOSTNAME_IN_ARGS=no
-for arg in "$@"; do
-  if [[ $arg =~ ^(-h|--help|help)$ ]]; then
-    usage
-    exit 0
-  fi
-  if [[ $arg =~ ^--hostname= ]]; then
-    TS_HOSTNAME=${arg#*=}
-    TS_HOSTNAME=${TS_HOSTNAME//[\"\']}
-    FOUND_HOSTNAME_IN_ARGS=yes
-  fi
+# Scan arguments looking for --hostname
+NEW_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    --hostname=*)
+      TS_HOSTNAME="${1#*=}"
+      TS_HOSTNAME=${TS_HOSTNAME//[\"\']}
+      shift
+      ;;
+    --hostname)
+      TS_HOSTNAME="$2"
+      TS_HOSTNAME=${TS_HOSTNAME//[\"\']}
+      shift 2
+      ;;
+    *)
+      NEW_ARGS+=("$1")
+      shift
+      ;;
+  esac
 done
-[[ $FOUND_HOSTNAME_IN_ARGS == yes ]] || set -- --hostname="$TS_HOSTNAME" "$@"
+set -- --hostname="$TS_HOSTNAME" "${NEW_ARGS[@]}"
 
 SETUPDIR="$(mktemp -d)"
 socket="${SETUPDIR}/tailscaled.sock"


### PR DESCRIPTION
This fixes a long-standing bug where using "--hostname x" (as opposed to "--hostname=x" resulted in duplication hostname switches being passed to the tailscale binary. Historically this bug has been masked by the fact that tailscale ignored all but the last of these, and the user-specified (non-default) one coincidentally got placed last. However, tailscale has recently started barfing on the duplicate switch so you could no longer use --hostname in the non-= form even though that's the form recommended in the documentation.